### PR TITLE
fix: actions/setup-node で指定するバージョンを .node-version を見るよう修正する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: '.node-version'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## やりたいこと

- actions/setup-node で指定するバージョンを .node-version を見るよう修正したい

## なぜなのか

- .node-version でバージョンを一元管理できる

## マージ後にやること

- 特になし
