### PR TITLE
fix: pinact を使って actions のバージョンを commit hash で固定する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version-file: '.node-version'
 


### PR DESCRIPTION
## やりたいこと

- [pinact](https://github.com/suzuki-shunsuke/pinact) を使って actions のバージョンを commit hash で固定したい 

## なぜなのか

- https://zenn.dev/shunsuke_suzuki/articles/pinact-pin-github-actions-version
  - Git タグが書き換えられ、参照している Workflow 内で悪意のあるコードが実行されてしまうという事態が発生しうるから

## マージ後にやること

- 特になし
