### PR TITLE
fix: テストを getAllByRole 使った形に書き換える

### DIFF
--- a/src/components/__tests__/ProfileLinks.spec.ts
+++ b/src/components/__tests__/ProfileLinks.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/vue'
+import { render } from '@testing-library/vue'
 
 import ProfileLinks from '../ProfileLinks.vue'
 
@@ -16,13 +16,19 @@ describe('ProfileLinks', () => {
   })
 
   test('リンクが正しい URL を指していること', () => {
-    const GitHubLink = screen.getByText('shinichiro-motoike')
-    expect(GitHubLink).toHaveAttribute('href', 'https://github.com/shinichiro-motoike')
-    const XLink = screen.getByText('moto_shin_')
-    expect(XLink).toHaveAttribute('href', 'https://x.com/moto_shin_')
-    const ZennLink = screen.getByText('motoshin')
-    expect(ZennLink).toHaveAttribute('href', 'https://zenn.dev/motoshin')
-    const QiitaLink = screen.getByText('shin_moto')
-    expect(QiitaLink).toHaveAttribute('href', 'https://qiita.com/shin_moto')
+    const { getAllByRole } = render(ProfileLinks)
+    const linkElements = getAllByRole('link')
+
+    expect(linkElements[0].textContent).toBe('shinichiro-motoike')
+    expect(linkElements[0]).toHaveAttribute('href', 'https://github.com/shinichiro-motoike')
+
+    expect(linkElements[1].textContent).toBe('moto_shin_')
+    expect(linkElements[1]).toHaveAttribute('href', 'https://x.com/moto_shin_')
+
+    expect(linkElements[2].textContent).toBe('motoshin')
+    expect(linkElements[2]).toHaveAttribute('href', 'https://zenn.dev/motoshin')
+
+    expect(linkElements[3].textContent).toBe('shin_moto')
+    expect(linkElements[3]).toHaveAttribute('href', 'https://qiita.com/shin_moto')
   })
 })

--- a/src/components/__tests__/ProfileLinks.spec.ts
+++ b/src/components/__tests__/ProfileLinks.spec.ts
@@ -5,13 +5,14 @@ import { render, screen } from '@testing-library/vue'
 import ProfileLinks from '../ProfileLinks.vue'
 
 describe('ProfileLinks', () => {
-  test('プロフィールが正しく表示できていること', () => {
-    render(ProfileLinks)
+  test('プロフィール項目の各ラベルが正しく表示できていること', () => {
+    const { getAllByRole } = render(ProfileLinks)
+    const dtElements = getAllByRole('term')
 
-    expect(screen.getByText('GitHub')).toBeInTheDocument()
-    expect(screen.getByText('X（Twitter）')).toBeInTheDocument()
-    expect(screen.getByText('Zenn')).toBeInTheDocument()
-    expect(screen.getByText('Qiita')).toBeInTheDocument()
+    expect(dtElements[0].textContent).toBe('GitHub')
+    expect(dtElements[1].textContent).toBe('X（Twitter）')
+    expect(dtElements[2].textContent).toBe('Zenn')
+    expect(dtElements[3].textContent).toBe('Qiita')
   })
 
   test('リンクが正しい URL を指していること', () => {


### PR DESCRIPTION
## やりたいこと

- プロフィールの各テストを getAllByRole 使った形に書き換えたい

## なぜなのか

- ByRole クエリで書けた方が良い
  - https://docs.google.com/presentation/d/1j6sEAs0LF5jPXs_mHxvPreqK-lxEL3OxvQAFyXmxbZc/view#slide=id.g25093711672_0_110

## マージ後にやること

- 特になし
