### PR TITLE
feat: カバレッジに含めないパスを指定する

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,17 @@ export default mergeConfig(
       exclude: [...configDefaults.exclude, 'e2e/**'],
       root: fileURLToPath(new URL('./', import.meta.url)),
       coverage: {
+        exclude: [
+          'env.d.ts',
+          'eslint.config.ts',
+          'playwright.config.ts',
+          'vite.config.ts',
+          'vitest.config.ts',
+          //TODO: 以下、暫定的に除外している
+          'src/App.vue',
+          'src/main.ts',
+          'src/components/icons/**',
+        ],
         provider: 'v8',
         reporter: ['text', 'json', 'html'],
         reportsDirectory: './tests/unit/coverage',


### PR DESCRIPTION
## やりたいこと

- カバレッジに含めないパスを指定する
  - https://vitest.dev/config/#coverage-exclude

## なぜなのか

- 必要ないので

## マージ後にやること

- 特になし
