### PR TITLE
fix: GitHub Actions ワークフローでは permissions をきちんと設定する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 on: pull_request
+permissions: {}
 
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## やりたいこと

- GitHub Actions ワークフローでは permissions をきちんと設定したい
- [suzuki-shunsuke/ghalint](https://github.com/suzuki-shunsuke/ghalint) を使って問題を確認した

## なぜなのか

- 最小の権限設定にしたいから

## マージ後にやること

- 特になし
