### PR TITLE
fix: actions/checkout には基本的に persist-credentials: 'false' に設定する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: 'false'
 
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0


### PR DESCRIPTION
## やりたいこと

- actions/checkout には基本的に persist-credentials: 'false' に設定したい

## なぜなのか

- トークンを永続化すると、その後の全ての step で actions/checkout トークンにアクセスできるようになり、これはセキュリティ上のリスクである
  - https://github.com/suzuki-shunsuke/ghalint/blob/main/docs/policies/013.md

## マージ後にやること

- 特になし
