### PR TITLE
fix: actions の job には timeout-minutes を設定する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ permissions: {}
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## やりたいこと

- actions の job には timeout-minutes を設定したい

## なぜなのか

>デフォルトでは、GitHub Actions は 6 時間経過してもワークフローが終了しない場合は、ワークフローを強制終了します。多くのワークフローは完了するのにそれほど長い時間を必要としませんが、予期しないエラーが発生したり、ワークフローの実行が開始から 6 時間経過して強制終了されるまでジョブがハングしたりすることがあります。そのため、より短いタイムアウトを指定することをお勧めします。
>
>理想的なタイムアウトは個々のワークフローによって異なりますが、Exercism リポジトリで使用されるワークフローでは通常 30 分で十分です。
>
>これには次の利点があります。
>
>PR は半日 CI を保留にすることがなくなり、問題を早期に発見したり、ワークフローの実行を再開したりできるようになります。全体的な並列ビルドの数は制限されており、ハングしているジョブが早期にキャンセルされた場合、他の PR に問題が発生することはありません。

## マージ後にやること

- 特になし
